### PR TITLE
Update project url default link

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,7 @@
     "author_name": "SunPy Developers",
     "author_email": "",
     "license": ["BSD 3-Clause", "GNU GPL v3+", "Apache Software Licence 2.0", "BSD 2-Clause", "Other"],
-    "project_url": "http://astropy.org",
+    "project_url": "http://sunpy.org",
     "project_version": "0.0.dev",
     "include_example_code": "y",
     "include_example_cython_code": "n",


### PR DESCRIPTION
It may not be needed... as in anycase this URL should be for the project and not for where it's affiliated.