### PR TITLE
Remove old isolated build option in tox

### DIFF
--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -7,7 +7,6 @@ envlist =
     py312-devdeps
     py39-oldestdeps
     build_docs
-isolated_build = true
 
 [testenv]
 pypi_filter = https://raw.githubusercontent.com/sunpy/sunpy/main/.test_package_pins.txt


### PR DESCRIPTION
See https://tox.wiki/en/4.13.0/upgrading.html#isolated-environment-on-by-default - since the min tox version is 4 I think it's safe to remove this.