### PR TITLE
Updates from OA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - macos: py39-test
-        - linux: py310-test
+        - macos: py310-test
         - linux: py311-test
         - linux: py312-test
         - linux: build_docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-test
+    py{310,311,312}-test
     build-docs
 
 [testenv]

--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 min_version = 4.0
 envlist =
-    py{38,39,310,311,312}-test
+    py{310,311,312}-test
     py38-test-oldestdeps
     build_docs
 

--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -2,7 +2,7 @@
 min_version = 4.0
 envlist =
     py{310,311,312}-test
-    py38-test-oldestdeps
+    py10-test-oldestdeps
     build_docs
 
 [testenv]


### PR DESCRIPTION
We can't autoupdate when the root ci config changes.