### PR TITLE
Indents publish_pure

### DIFF
--- a/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
@@ -119,14 +119,14 @@ jobs:
     secrets:
       pypi_token: {{ '${{ secrets.pypi_token }}' }}
 {%- else -%}
-  publish_pure:
-    needs: [test, docs]
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@main
-    with:
-      python-version: '{{ default_python }}'
-      test_extras: 'tests'
-      test_command: 'pytest -p no:warnings --doctest-rst --pyargs {{ cookiecutter.module_name }}'
-      submodules: false
-    secrets:
-      pypi_token: {{ '${{ secrets.pypi_token }}' }}
+    publish_pure:
+      needs: [test, docs]
+      uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@main
+      with:
+        python-version: '{{ default_python }}'
+        test_extras: 'tests'
+        test_command: 'pytest -p no:warnings --doctest-rst --pyargs {{ cookiecutter.module_name }}'
+        submodules: false
+      secrets:
+        pypi_token: {{ '${{ secrets.pypi_token }}' }}
 {%- endif %}


### PR DESCRIPTION
## PR Description

When I was trying out the package template, the CI pretty much instantly failed saying `The workflow is not valid. .github/workflows/ci.yml (Line: 93, Col: 1): Unexpected value 'publish_pure'`. I think it's because everything under `publish_pure` should be indented once more. That seemed to help the CI get further for me. This may be wrong though, so please guide me on the correct solution. 