### PR TITLE
Better version parsing for docs build

### DIFF
--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -13,16 +13,15 @@ from packaging.version import Version
 # The full version, including alpha/beta/rc tags
 from {{ cookiecutter.module_name }} import __version__
 
-_version_ = Version(__version__)
-# NOTE: Avoid "post" appearing in version string in rendered docs
-if _version_.is_postrelease:
-    version = release = _version_.base_version
-# NOTE: Avoid long githashes in rendered Sphinx docs
-elif _version_.is_devrelease:
-    version = release = f'{_version_.base_version}.dev{_version_.dev}'
-else:
-    version = release = str(_version_)
-is_development = _version_.is_devrelease
+_version = Version(__version__)
+version = release = str(_version)
+# Avoid "post" appearing in version string in rendered docs
+if _version.is_postrelease:
+    version = release = _version.base_version
+# Avoid long githashes in rendered Sphinx docs
+elif _version.is_devrelease:
+    version = release = f'{_version.base_version}.dev{_version.dev}'
+is_development = _version.is_devrelease
 
 project = "{{ cookiecutter.package_name }}"
 author = "{{ cookiecutter.author_name }}"

--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -16,10 +16,10 @@ from {{ cookiecutter.module_name }} import __version__
 _version_ = Version(__version__)
 # NOTE: Avoid "post" appearing in version string in rendered docs
 if _version_.is_postrelease:
-    version = release = f'{_version_.major}.{_version_.minor}.{_version_.micro}'
+    version = release = _version_.base_version
 # NOTE: Avoid long githashes in rendered Sphinx docs
 elif _version_.is_devrelease:
-    version = release = f'{_version_.major}.{_version_.minor}.dev{_version_.dev}'
+    version = release = f'{_version_.base_version}.dev{_version_.dev}'
 else:
     version = release = str(_version_)
 is_development = _version_.is_devrelease

--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -6,12 +6,23 @@
 
 import datetime
 
+from packaging.version import Version
+
 # -- Project information -----------------------------------------------------
 
 # The full version, including alpha/beta/rc tags
 from {{ cookiecutter.module_name }} import __version__
 
-release = __version__
+_version_ = Version(__version__)
+# NOTE: Avoid "post" appearing in version string in rendered docs
+if _version_.is_postrelease:
+    version = release = f'{_version_.major}.{_version_.minor}.{_version_.micro}'
+# NOTE: Avoid long githashes in rendered Sphinx docs
+elif _version_.is_devrelease:
+    version = release = f'{_version_.major}.{_version_.minor}.dev{_version_.dev}'
+else:
+    version = release = str(_version_)
+is_development = _version_.is_devrelease
 
 project = "{{ cookiecutter.package_name }}"
 author = "{{ cookiecutter.author_name }}"

--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -42,6 +42,7 @@ tests = [
 docs = [
   "sphinx",
   "sphinx-automodapi",
+  "packaging",
 ]
 
 {%- if cookiecutter.project_url %}


### PR DESCRIPTION
This is a relatively opinionated choice, but I've found that it's often useful to exclude parts of the version string when rendering the docs and its easiest to do that by first converting this to a `Version` object. 

This excludes the usually overly long hash from the version string that gets passed to Sphinx and also excludes post tags on versions so that if post versions are needed, they show up as the same version in the rendered docs.

If this is overly opinionated, feel free to close. I've duplicated this snippet in several doc builds recently so thought it might be worth upstreaming. 