### PR TITLE
Fix package name in towncrier configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,9 @@ def bake_examples(cookies):
     """
     Examples on.
     """
-    result = cookies.bake(extra_context={"include_example_code": "y",
+    result = cookies.bake(extra_context={"package_name": "example-package",
+                                         "module_name": "example_package",
+                                         "include_example_code": "y",
                                          "author_name": "test",
                                          "use_extended_ruff_linting": "y"})
     return _handle_cookiecutter_errors(result)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -37,7 +37,7 @@ def test_examples_present(cookiejar_examples):
         example_files.append("example_c.pyx")
 
     for afile in example_files:
-        assert (cj.project_path / ctx['package_name'] / afile).exists()
+        assert (cj.project_path / ctx['module_name'] / afile).exists()
 
 
 @pytest.mark.parametrize("license, lfile", [

--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -108,7 +108,7 @@ write_to = "{{ cookiecutter.module_name }}/version.py"
 # TODO: This should be in towncrier.toml but Giles currently only works looks in
 # pyproject.toml we should move this back when it's fixed.
 [tool.towncrier]
-  package = "{{ cookiecutter.package_name }}"
+  package = "{{ cookiecutter.module_name }}"
   filename = "CHANGELOG.rst"
   directory = "changelog/"
   issue_format = "`#{issue} <https://github.com/{{ cookiecutter.github_repo | default('sunpy/sunpy') }}/pull/{issue}>`__"


### PR DESCRIPTION
Update towncrier config to use `cookiecutter.module_name`

Closes #160