### PR TITLE
Drop =<3.11 and add 3.13 and 3.14 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@28e947497bed4d6ec3fa1d66d198e95a1d17bc63  # v2.2.1
     with:
       envs: |
-        - mac: py312-test
+        - macos: py312-test
         - linux: py313-test
         - linux: py314-test
         - linux: build_docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@28e947497bed4d6ec3fa1d66d198e95a1d17bc63  # v2.2.1
     with:
       envs: |
-        - macos: py311-test
-        - linux: py312-test
+        - mac: py312-test
         - linux: py313-test
         - linux: py314-test
         - linux: build_docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
         - macos: py311-test
         - linux: py312-test
         - linux: py313-test
+        - linux: py314-test
         - linux: build_docs
 
   bake_cookies:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,7 +19,6 @@
         "Other"
     ],
     "minimum_python_version": [
-        "3.11",
         "3.12",
         "3.13",
         "3.14"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -21,8 +21,8 @@
     "minimum_python_version": [
         "3.11",
         "3.12",
-	    "3.13",
-	    "3.14"
+        "3.13",
+        "3.14"
     ],
     "use_compiled_extensions": "n",
     "enable_dynamic_dev_versions": "n",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,10 +19,11 @@
         "Other"
     ],
     "minimum_python_version": [
-        "3.9",
         "3.10",
         "3.11",
-        "3.12"
+        "3.12",
+	"3.13",
+	"3.14"
     ],
     "use_compiled_extensions": "n",
     "enable_dynamic_dev_versions": "n",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,7 +19,6 @@
         "Other"
     ],
     "minimum_python_version": [
-        "3.10",
         "3.11",
         "3.12",
 	    "3.13",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312}-test
+    py{310,311,312,313,314}-test
     bake_cookies
     build-docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312,313,314}-test
+    py{312,313,314}-test
     bake_cookies
     build-docs
 

--- a/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '{{ default_python }}'
       - run: python -m pip install -U --user build

--- a/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Main CI Workflow {%- set default_python = '3.14' %}
+# Main CI Workflow {%- set default_python = '3.13' %}
 name: CI
 
 on:
@@ -35,7 +35,7 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       envs: |
-        - linux: py314
+        - linux: py313
     secrets:
       CODECOV_TOKEN: {{ '${{ secrets.CODECOV_TOKEN }}' }}
 
@@ -60,10 +60,11 @@ jobs:
       toxdeps: tox-pypi-filter
       posargs: -n auto
       envs: |
+        - linux: py314
         - windows: py312
         - macos: py312
         - linux: py312-oldestdeps
-        - linux: py313-devdeps
+        - linux: py314-devdeps
     secrets:
       CODECOV_TOKEN: {{ '${{ secrets.CODECOV_TOKEN }}' }}
 

--- a/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
   test:
     needs: [core, sdist_verify]
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
       coverage: codecov

--- a/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Main CI Workflow {%- set default_python = '3.12' %}
+# Main CI Workflow {%- set default_python = '3.13' %}
 name: CI
 
 on:
@@ -108,10 +108,10 @@ jobs:
       test_command: 'pytest -p no:warnings --doctest-rst --pyargs {{ cookiecutter.module_name }}'
       submodules: false
       targets: |
-        - cp3{9,10,11,12}-manylinux*_x86_64
-        - cp3{9,10,11,12}-macosx_x86_64
-        - cp3{9,10,11,12}-macosx_arm64
-        - cp3{9,10,11,12}-win_amd64
+        - cp3{9,10,11,12,13,14}-manylinux*_x86_64
+        - cp3{9,10,11,12,13,14}-macosx_x86_64
+        - cp3{9,10,11,12,13,14}-macosx_arm64
+        - cp3{9,10,11,12,13,14}-win_amd64
 {%- else %}
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:

--- a/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
@@ -99,10 +99,10 @@ jobs:
       test_command: 'pytest -p no:warnings --doctest-rst --pyargs {{ cookiecutter.module_name }}'
       submodules: false
       targets: |
-        - cp3{11,12,13,14}-manylinux*_x86_64
-        - cp3{11,12,13,14}-macosx_x86_64
-        - cp3{11,12,13,14}-macosx_arm64
-        - cp3{11,12,13,14}-win_amd64
+        - cp3{12,13,14}-manylinux*_x86_64
+        - cp3{12,13,14}-macosx_x86_64
+        - cp3{12,13,14}-macosx_arm64
+        - cp3{12,13,14}-win_amd64
 {%- else %}
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v2
     with:

--- a/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Main CI Workflow {%- set default_python = '3.12' %}
+# Main CI Workflow {%- set default_python = '3.14' %}
 name: CI
 
 on:
@@ -35,7 +35,7 @@ jobs:
       coverage: codecov
       toxdeps: tox-pypi-filter
       envs: |
-        - linux: py313
+        - linux: py314
     secrets:
       CODECOV_TOKEN: {{ '${{ secrets.CODECOV_TOKEN }}' }}
 
@@ -60,9 +60,9 @@ jobs:
       toxdeps: tox-pypi-filter
       posargs: -n auto
       envs: |
-        - windows: py311
+        - windows: py312
         - macos: py312
-        - linux: py310-oldestdeps
+        - linux: py312-oldestdeps
         - linux: py313-devdeps
     secrets:
       CODECOV_TOKEN: {{ '${{ secrets.CODECOV_TOKEN }}' }}

--- a/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
@@ -99,10 +99,10 @@ jobs:
       test_command: 'pytest -p no:warnings --doctest-rst --pyargs {{ cookiecutter.module_name }}'
       submodules: false
       targets: |
-        - cp3{10,11,12,13,14}-manylinux*_x86_64
-        - cp3{10,11,12,13,14}-macosx_x86_64
-        - cp3{10,11,12,13,14}-macosx_arm64
-        - cp3{10,11,12,13,14}-win_amd64
+        - cp3{11,12,13,14}-manylinux*_x86_64
+        - cp3{11,12,13,14}-macosx_x86_64
+        - cp3{11,12,13,14}-macosx_arm64
+        - cp3{11,12,13,14}-win_amd64
 {%- else %}
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v2
     with:

--- a/{{ cookiecutter.package_name }}/.github/workflows/sub_package_update.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/sub_package_update.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -3,9 +3,9 @@ min_version = 4.0
 requires =
     tox-pypi-filter>=0.14
 envlist =
-    py{310,311,312}
-    py312-devdeps
-    py310-oldestdeps
+    py{312,313,314}
+    py314-devdeps
+    py312-oldestdeps
     codestyle
     build_docs
 


### PR DESCRIPTION
Adds ci applications for 3.13 and 3,14
Removed 3.9 as a min python option in cookiecutter