### PR TITLE
Update pre-commit config to use file, type and type_or instead of exc…

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -55,3 +55,6 @@ if __name__ == '__main__':
         remove_dir('{{ cookiecutter.module_name }}/example_subpkg/')
         remove_file('{{ cookiecutter.module_name }}/example_mod.py')
         remove_file('{{ cookiecutter.module_name }}/tests/test_example.py')
+        remove_file('{{ cookiecutter.module_name }}/data/__init__.py')
+        remove_file('{{ cookiecutter.module_name }}/data/test.toml')
+        remove_file('{{ cookiecutter.module_name }}/data/test.yml')

--- a/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
@@ -46,11 +46,12 @@ repos:
       - id: codespell
         args: [ "--write-changes" ]
         types_or: [python, rst]
-        exclude: &exclude_dirs
+        exclude: *exclude_dirs
   - repo: meta
     hooks:
       - id: check-hooks-apply
-      - id: check-useless-excludes
+      # Uncomment to make sure the ecludes match something
+      # - id: check-useless-excludes
 ci:
   autofix_prs: false
   autoupdate_schedule: "quarterly"

--- a/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
@@ -5,31 +5,47 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
+        types: [python]
+        files: ^{{ cookiecutter.module_name }}/(?!(extern|io/src/ana)/)
   - repo: https://github.com/PyCQA/isort
     rev: 8.0.1
     hooks:
       - id: isort
-        exclude: ".*(.fits|.fts|.fit|.header|.txt|tca.*|extern.*|{{ cookiecutter.module_name }}/extern)$"
+        types: [python]
+        files: ^{{ cookiecutter.module_name }}/(?!(extern|io/src/ana)/)
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-ast
+        types: [python]
       - id: check-case-conflict
+        types: [python]
       - id: trailing-whitespace
-        exclude: ".*(.fits|.fts|.fit|.header|.txt)$"
+        types_or: [python, rst]
+        files: ^{{ cookiecutter.module_name }}/(?!(data|extern|io/src/ana)/)
       - id: check-yaml
+        types: [yaml]
       - id: debug-statements
+        types: [python]
       - id: check-added-large-files
         args: ["--enforce-all", "--maxkb=1054"]
       - id: end-of-file-fixer
-        exclude: ".*(.fits|.fts|.fit|.header|.txt|tca.*|.json)$|^CITATION.rst$"
+        types_or: [python, rst]
+        files: ^{{ cookiecutter.module_name }}/(?!(data|extern|io/src/ana)/)
       - id: mixed-line-ending
-        exclude: ".*(.fits|.fts|.fit|.header|.txt|tca.*)$"
+        types_or: [python, rst]
+        files: ^{{ cookiecutter.module_name }}/(?!(data|extern|io/src/ana)/)
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
       - id: codespell
         args: [ "--write-changes" ]
+        types_or: [python, rst]
+        files: ^{{ cookiecutter.module_name }}/(?!(data|extern|io/src/ana)/)
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
 ci:
   autofix_prs: false
   autoupdate_schedule: "quarterly"

--- a/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+files: ^{{ cookiecutter.module_name }}/(?!(extern|data)/)
 repos:
     # This should be before any formatting hooks like isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -6,7 +7,7 @@ repos:
       - id: ruff
         args: ["--fix"]
         types: [python]
-        files: ^{{ cookiecutter.module_name }}/(?!(extern|io/src/ana)/)
+
   - repo: https://github.com/PyCQA/isort
     rev: 8.0.1
     hooks:
@@ -22,26 +23,24 @@ repos:
         types: [python]
       - id: trailing-whitespace
         types_or: [python, rst]
-        files: ^{{ cookiecutter.module_name }}/(?!(data|extern|io/src/ana)/)
       - id: check-yaml
         types: [yaml]
       - id: debug-statements
         types: [python]
       - id: check-added-large-files
         args: ["--enforce-all", "--maxkb=1054"]
+        # Override top level to check all files
+        files: ""
       - id: end-of-file-fixer
         types_or: [python, rst]
-        files: ^{{ cookiecutter.module_name }}/(?!(data|extern|io/src/ana)/)
       - id: mixed-line-ending
         types_or: [python, rst]
-        files: ^{{ cookiecutter.module_name }}/(?!(data|extern|io/src/ana)/)
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
       - id: codespell
         args: [ "--write-changes" ]
         types_or: [python, rst]
-        files: ^{{ cookiecutter.module_name }}/(?!(data|extern|io/src/ana)/)
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-files: ^{{ cookiecutter.module_name }}/(?!(extern|data)/)
 repos:
     # This should be before any formatting hooks like isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -7,30 +6,36 @@ repos:
       - id: ruff
         args: ["--fix"]
         types: [python]
-
+        # Define here once and then reference using YAML anchor
+        exclude: &exclude_dirs ^{{ cookiecutter.module_name }}/(data|extern)/
   - repo: https://github.com/PyCQA/isort
     rev: 8.0.1
     hooks:
       - id: isort
         types: [python]
-        files: ^{{ cookiecutter.module_name }}/(?!(extern|io/src/ana)/)
+        exclude: *exclude_dirs
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-ast
         types: [python]
+        exclude: *exclude_dirs
       - id: check-case-conflict
         types: [python]
+        exclude: *exclude_dirs
       - id: trailing-whitespace
         types_or: [python, rst]
       - id: check-yaml
         types: [yaml]
+        exclude: *exclude_dirs
+      - id: check-toml
+        types: [toml]
+        exclude: *exclude_dirs
       - id: debug-statements
         types: [python]
+        exclude: *exclude_dirs
       - id: check-added-large-files
         args: ["--enforce-all", "--maxkb=1054"]
-        # Override top level to check all files
-        files: ""
       - id: end-of-file-fixer
         types_or: [python, rst]
       - id: mixed-line-ending
@@ -41,6 +46,7 @@ repos:
       - id: codespell
         args: [ "--write-changes" ]
         types_or: [python, rst]
+        exclude: &exclude_dirs
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
@@ -50,8 +50,8 @@ repos:
   - repo: meta
     hooks:
       - id: check-hooks-apply
-      # Uncomment to make sure the ecludes match something
-      # - id: check-useless-excludes
+      # This may fail if you do not have matching files in the data/ or extern/ directories
+      - id: check-useless-excludes
 ci:
   autofix_prs: false
   autoupdate_schedule: "quarterly"

--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/data/__init__.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/data/__init__.py
@@ -1,0 +1,3 @@
+"""
+This folder is for data and helpers for data.
+"""

--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/data/test.toml
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/data/test.toml
@@ -1,0 +1,1 @@
+# This file exists to make tests on the package template happy.

--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/data/test.yml
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/data/test.yml
@@ -1,0 +1,1 @@
+# This file exists to make tests on the package template happy.


### PR DESCRIPTION
Switch to specifying the type and file we want the checks to run on rather than excluding those that we don't. I think this is more explicit and I think marginally more maintainable. If we add `.md` files just need to add `markdown` to the `types` or `types_or`

Need to agree the type which checks should run on closes #247 