### PR TITLE
Add a way to add extra CI jobs via the template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -30,6 +30,7 @@
     "include_cruft_update_github_workflow": "n",
     "use_extended_ruff_linting": "n",
     "matrix_room_id": "",
+    "extra_ci_jobs": "",
     "_sphinx_theme": "sunpy",
     "_parent_project": "",
     "_install_requires": "",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,7 @@ def bake_examples_compiled_dev_version(cookies):
             "use_extended_ruff_linting": "y",
             "download_url": "https://github.com/sunpy/sunpy/archive/master.zip",
             "issue_tracker_url": "https://github.com/sunpy/sunpy/issues",
+            "extra_ci_jobs": "online,threading",
         }
     )
     return _handle_cookiecutter_errors(result)

--- a/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/ci.yml
@@ -86,6 +86,18 @@ jobs:
       envs: |
         - linux: build_docs
 
+  {%- if cookiecutter.extra_ci_jobs -%}
+  {% for env in cookiecutter.extra_ci_jobs.split(',') %}
+  {{ env }}:
+    needs: [core]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c8bb6c6c962542921f993d47d26df38dccd50b1  # v3.0.2
+    with:
+      submodules: false
+      toxdeps: tox-pypi-filter
+      envs: |
+  {% endfor -%}
+  {%- endif %}
+
   build_dists:
     # Build wheels on PRs only when labelled. Releases will only be published if tagged ^v.*
     # see https://github-actions-workflows.openastronomy.org/en/latest/publish.html#upload-to-pypi


### PR DESCRIPTION
This should help to reduce conflicts and means this workflow action will be updated via the template PRs and not dependabot.

Note to a reviewer: if you want to check if this works you should download the cookies artifact to see the template outputs.