### PR TITLE
Add extra_content and PAT support to sub_package_update workflow

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -28,7 +28,7 @@
     "enable_dynamic_dev_versions": "n",
     "include_example_code": "n",
     "include_cruft_update_github_workflow": "n",
-    "use_pat_in_cruft_update_workflow": "n",
+    "use_pat_in_cruft_update_workflow": "y",
     "use_extended_ruff_linting": "n",
     "matrix_room_id": "",
     "extra_ci_jobs": "",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -28,6 +28,7 @@
     "enable_dynamic_dev_versions": "n",
     "include_example_code": "n",
     "include_cruft_update_github_workflow": "n",
+    "use_pat_in_cruft_update_workflow": "n",
     "use_extended_ruff_linting": "n",
     "matrix_room_id": "",
     "extra_ci_jobs": "",
@@ -36,8 +37,7 @@
     "_install_requires": "",
     "_copy_without_render": [
         "docs/_templates",
-        "docs/_static",
-        ".github/workflows/sub_package_update.yml"
+        "docs/_static"
     ],
     "__prompts__" : {
         "project_url": "Primary website for the project, leave blank for Sunpy Homepage",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,8 @@ def bake_examples_url_extensions(cookies):
             "documentation_url": "https://sunpy.org/docs",
             "changelog_url": "https://sunpy.org/changelog",
             "issue_tracker_url": "https://github.com/sunpy/sunpy/issues",
+            "include_cruft_update_github_workflow": "y",
+            "use_pat_in_cruft_update_workflow": "y",
         }
     )
     return _handle_cookiecutter_errors(result)

--- a/{{ cookiecutter.package_name }}/.github/workflows/sub_package_update.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/sub_package_update.yml
@@ -5,6 +5,12 @@ name: Automatic Update from package template
 on:
   # Allow manual runs through the web UI
   workflow_dispatch:
+    inputs:
+      extra_context:
+        description: 'JSON of cookiecutter variables to update (passed to cruft --variables-to-update), e.g. {"project": "new-name"}'
+        required: false
+        default: ''
+        type: string
   schedule:
     #        ┌───────── minute (0 - 59)
     #        │ ┌───────── hour (0 - 23)
@@ -19,8 +25,15 @@ jobs:
   update:
     runs-on: ubuntu-latest
     permissions:
+      {%- if cookiecutter.use_pat_in_cruft_update_workflow == "n" %}
       contents: write
+      {%- endif %}
       pull-requests: write
+    {%- if cookiecutter.use_pat_in_cruft_update_workflow == "y" %}
+    environment:
+      name: sub_package_update
+      deployment: false
+    {%- endif %}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -51,11 +64,18 @@ jobs:
       - name: Run update if available
         id: cruft_update
         if: steps.check.outputs.has_changes == '1'
+        env:
+          EXTRA_CONTEXT: {{ '${{ inputs.extra_context }}' }}
         run: |
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"
 
-          cruft_output=$(cruft update --skip-apply-ask --refresh-private-variables)
+          EXTRA_ARGS=()
+          if [ -n "$EXTRA_CONTEXT" ]; then
+            EXTRA_ARGS=(--variables-to-update "$EXTRA_CONTEXT")
+          fi
+
+          cruft_output=$(cruft update --skip-apply-ask --refresh-private-variables "${EXTRA_ARGS[@]}")
           echo $cruft_output
           git restore --staged .
 
@@ -81,12 +101,15 @@ jobs:
         if: steps.cruft_json.outputs.has_changes == '1'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: {{ '${{ secrets.GITHUB_TOKEN }}' }}
+          {%- if cookiecutter.use_pat_in_cruft_update_workflow == "y" %}
+          branch-token: {{ '${{ secrets.WORKFLOWS_UPDATE_PAT }}' }}
+          {%- endif %}
           add-paths: "."
           commit-message: "Automatic package template update"
           branch: "cruft/update"
           delete-branch: true
-          draft: ${{ steps.cruft_update.outputs.merge_conflicts == '1' }}
+          draft: {{ "${{ steps.cruft_update.outputs.merge_conflicts == '1' }}" }}
           title: "Updates from the package template"
           labels: |
             No Changelog Entry Needed
@@ -106,7 +129,7 @@ jobs:
       - name: Open an issue if workflow fails
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
-          github-token: ${{ github.token }}
+          github-token: {{ '${{ github.token }}' }}
           # This script is adapted from https://github.com/scientific-python/issue-from-pytest-log-action
           # Under MIT license (c) Scientific Python Developers
           script: |


### PR DESCRIPTION
This is a corollary to #288 for repos not in the sunpy github org. Repos outside the org still need to use the sub_package_update.yml workflow, but now they *really* want to use a PAT because of the frequent updates to the workflows.

Also this adds the extra_content feature from the centralised_updater as that's sometimes useful.

@nabobalis FYI given your use of this repo.