### PR TITLE
Move zizmor from pre-commit to action

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -37,7 +37,8 @@
     "_install_requires": "",
     "_copy_without_render": [
         "docs/_templates",
-        "docs/_static"
+        "docs/_static",
+        ".github/workflows/zizmor.yml"
     ],
     "__prompts__" : {
         "project_url": "Primary website for the project, leave blank for Sunpy Homepage",

--- a/{{ cookiecutter.package_name }}/.github/workflows/zizmor.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1

--- a/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.package_name }}/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 repos:
-  - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.28.0
-    hooks:
-      - id: zizmor
     # This should be before any formatting hooks like isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.16.1"


### PR DESCRIPTION
I think now that #222 is done the main blocker of doing this as a GitHub action (the recommended way) has gone, but I need to test it out somewhere first.